### PR TITLE
Add tests/data-files/external to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+tests/data-files/external
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
External data is re-enabled in https://github.com/stac-utils/stactools/commit/eabd76323670f1ecdb2d9c71240a80763d5d7130, and that directory should be ignore by git.