### PR TITLE
Re-fix rename script for OSX

### DIFF
--- a/scripts/rename
+++ b/scripts/rename
@@ -6,7 +6,7 @@ name="$(basename $(cd "$(dirname $(dirname "$0"))"; pwd -P))"
 underscore_name=${name//-/_}
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    sedflags="-i ''"
+    sedflags="-i.original"
 else
     sedflags="-i"
 fi
@@ -30,5 +30,7 @@ done
 if [ -d src/stactools/package ]; then
     git mv src/stactools/package "src/stactools/$underscore_name"
 fi
+
+git clean -fd
 
 echo "Don't forget to manually update setup.cfg and README.md"


### PR DESCRIPTION
**Related Issue(s):** #25, #26 

**Description:** The old fix left a bunch of files with a '' suffix. I couldn't find an easy way to get the inplace editing to work without leaving behind leftover files, so I went with a `git clean -fd` instead.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- ~[ ] Documentation has been updated to reflect changes, if applicable.~
- ~[ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).~
