### PR TITLE
Fix a little bit of wording in the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ Steps to reproduce the behavior:
 
 > Ex.
 >
-> 1. Install stactools and stactools-package dataset
+> 1. Install stactools-package
 > 2. Run `scripts/test`
 > 3. See error
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,7 +11,7 @@ assignees: ''
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen. Ex. I would like to use stac <dataset> to do [...]
+A clear and concise description of what you want to happen. Ex. I would like to use stac <package> to do [...]
 
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.


### PR DESCRIPTION
**Related Issue(s):** n/a

**Description:** Not all stactools packages are datasets (e.g. `stactools-browse`) so the wording should be more general. Also, all stactools packages depend on stactools so the user just needs to install the package.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- ~[ ] Documentation has been updated to reflect changes, if applicable.~
- ~[ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).~
