### PR TITLE
Fix rename script `sed -i` compatibility

### DIFF
--- a/scripts/rename
+++ b/scripts/rename
@@ -6,7 +6,7 @@ name="$(basename $(cd "$(dirname $(dirname "$0"))"; pwd -P))"
 underscore_name=${name//-/_}
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    sedflags="-i ''"
+    sedflags="-i.original"
 else
     sedflags="-i"
 fi
@@ -30,5 +30,7 @@ done
 if [ -d src/stactools/package ]; then
     git mv src/stactools/package "src/stactools/$underscore_name"
 fi
+
+git clean -fd
 
 echo "Don't forget to manually update setup.cfg and README.md"

--- a/scripts/rename
+++ b/scripts/rename
@@ -6,12 +6,12 @@ name="$(basename $(cd "$(dirname $(dirname "$0"))"; pwd -P))"
 underscore_name=${name//-/_}
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    sedflags="-i.original"
+    sedflags=(-i "")
 else
-    sedflags="-i"
+    sedflags=(-i)
 fi
 
-for file in $(find . -not \( -name .git -prune \) -a -type f); do
+for file in $(find . -not \( -name .git -prune \) -not \( -name __pycache__ -prune \) -a -type f); do
     file_name=$(basename "$file")
     case $file_name in
         CONTRIBUTING.MD|README.md|rename|setup.cfg|publish|installation_and_basic_usage.ipynb)
@@ -19,18 +19,16 @@ for file in $(find . -not \( -name .git -prune \) -a -type f); do
             continue;;
     esac
     set +e
-    sed ${sedflags} -e "s/stactools-package/stactools-${name}/g" $file
-    sed ${sedflags} -e "s/stactools\.package/stactools.${underscore_name}/g" $file
-    sed ${sedflags} -e "s/stactools_package/stactools_${underscore_name}/g" $file
-    sed ${sedflags} -e "s;stactools/package;stactools/${underscore_name};g" $file
-    sed ${sedflags} -e "s/package-name/${name}/g" $file
+    sed "${sedflags[@]}" -e "s/stactools-package/stactools-${name}/g" $file
+    sed "${sedflags[@]}" -e "s/stactools\.package/stactools.${underscore_name}/g" $file
+    sed "${sedflags[@]}" -e "s/stactools_package/stactools_${underscore_name}/g" $file
+    sed "${sedflags[@]}" -e "s;stactools/package;stactools/${underscore_name};g" $file
+    sed "${sedflags[@]}" -e "s/package-name/${name}/g" $file
     set -e
 done
 
 if [ -d src/stactools/package ]; then
     git mv src/stactools/package "src/stactools/$underscore_name"
 fi
-
-git clean -fd
 
 echo "Don't forget to manually update setup.cfg and README.md"


### PR DESCRIPTION
Use shell arrays to pass `sed -i` params for compatibility across GNU and BSD.