### PR TITLE
Allow stactools versions with extra_requires

### DIFF
--- a/scripts/stactools-version.py
+++ b/scripts/stactools-version.py
@@ -2,11 +2,11 @@ from setuptools.config import read_configuration
 
 conf_dict = read_configuration("setup.cfg")
 
-# Filter out entries that don't start with 'stactools '.
+# Filter out entries that don't start with 'stactools ' or 'stactools['.
 # Split the entry on whitespace and select the last item which should be the version.
 version = [
     req for req in conf_dict['options']['install_requires']
-    if req.startswith('stactools ')
+    if req.startswith('stactools ') or req.startswith('stactools[')
 ][0].split().pop()
 
 print(version)


### PR DESCRIPTION
**Related Issue(s):** n/a

**Description:** Now that stactools has extra_requires (https://github.com/stac-utils/stactools/commit/5e0d1b62f6d599a67184dd071f0dabb037470e4f) we need to allow that type of version specification.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- ~[ ] Documentation has been updated to reflect changes, if applicable.~
- ~[ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).~
