### PR TITLE
Ignore more files with editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -31,3 +31,12 @@ indent_size = unset
 
 [*.yml]
 indent_size = 2
+
+# File extensions to completely ignore
+[*.{tif}]
+end_of_line = unset
+end_of_line = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+indent_style = unset
+indent_size = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -31,12 +31,3 @@ indent_size = unset
 
 [*.yml]
 indent_size = 2
-
-# File extensions to completely ignore
-[*.{tif}]
-end_of_line = unset
-end_of_line = unset
-insert_final_newline = unset
-trim_trailing_whitespace = unset
-indent_style = unset
-indent_size = unset

--- a/scripts/lint
+++ b/scripts/lint
@@ -13,7 +13,7 @@ Execute project linters.
 "
 }
 
-EC_EXCLUDE="(__pycache__|.git|.coverage|coverage.xml|.*\.egg-info)"
+EC_EXCLUDE="(__pycache__|.git|.coverage|coverage.xml|.*\.egg-info|.mypy_cache)"
 
 DIRS_TO_CHECK=("src" "tests" "scripts")
 

--- a/scripts/lint
+++ b/scripts/lint
@@ -13,7 +13,7 @@ Execute project linters.
 "
 }
 
-EC_EXCLUDE="(__pycache__|.git|.coverage|coverage.xml|.*\.egg-info|.mypy_cache)"
+EC_EXCLUDE="(__pycache__|.git|.coverage|coverage.xml|.*\.egg-info|.mypy_cache|.tif|.tiff)"
 
 DIRS_TO_CHECK=("src" "tests" "scripts")
 


### PR DESCRIPTION
**Related Issue(s):** n/a

**Description:** Docker builds were trying to check line endings on tiff files and in the mypy cache in one of our dataset packages.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- ~[ ] Documentation has been updated to reflect changes, if applicable.~
- ~[ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).~
