### PR TITLE
`editorconfig-checker`'s exe name was changed to `ec`

### DIFF
--- a/scripts/lint
+++ b/scripts/lint
@@ -22,7 +22,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage
     else
         # Text formatting
-        editorconfig-checker --exclude "$EC_EXCLUDE"
+        ec --exclude "$EC_EXCLUDE"
         # Code formatting
         yapf -dpr ${DIRS_TO_CHECK[@]}
         # Lint


### PR DESCRIPTION
A consequence of not pinning dev dependencies

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] ~Documentation has been updated to reflect changes, if applicable.~
- [ ] ~Changes are added to the [CHANGELOG](../CHANGELOG.md).~
