### PR TITLE
Add isort

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ codespell
 coverage
 editorconfig-checker
 flake8
+isort
 jupyter
 mypy
 pylint

--- a/scripts/format
+++ b/scripts/format
@@ -19,6 +19,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
+        # Sort imports
+        isort --overwrite-in-place .
         # Code formatting
         yapf -ipr ${DIRS_TO_CHECK[@]}
     fi

--- a/scripts/lint
+++ b/scripts/lint
@@ -23,6 +23,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     else
         # Text formatting
         ec --exclude "$EC_EXCLUDE"
+        # Sort imports
+        isort --check .
         # Code formatting
         yapf -dpr ${DIRS_TO_CHECK[@]}
         # Lint

--- a/src/stactools/ephemeral/__init__.py
+++ b/src/stactools/ephemeral/__init__.py
@@ -1,4 +1,5 @@
 import stactools.core
+
 from stactools.ephemeral.stac import create_collection, create_item
 
 __all__ = ['create_collection', 'create_item']

--- a/src/stactools/ephemeral/commands.py
+++ b/src/stactools/ephemeral/commands.py
@@ -1,5 +1,6 @@
-import click
 import logging
+
+import click
 
 from stactools.ephemeral import stac
 

--- a/src/stactools/ephemeral/stac.py
+++ b/src/stactools/ephemeral/stac.py
@@ -1,18 +1,8 @@
-from datetime import datetime, timezone
 import logging
+from datetime import datetime, timezone
 
-from pystac import (
-    Collection,
-    Item,
-    Asset,
-    Provider,
-    ProviderRole,
-    Extent,
-    SpatialExtent,
-    TemporalExtent,
-    CatalogType,
-    MediaType,
-)
+from pystac import (Asset, CatalogType, Collection, Extent, Item, MediaType,
+                    Provider, ProviderRole, SpatialExtent, TemporalExtent)
 from pystac.extensions.projection import ProjectionExtension
 
 logger = logging.getLogger(__name__)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,8 +2,9 @@ import os.path
 from tempfile import TemporaryDirectory
 
 import pystac
-from stactools.ephemeral.commands import create_ephemeralcmd_command
 from stactools.testing import CliTestCase
+
+from stactools.ephemeral.commands import create_ephemeralcmd_command
 
 
 class CommandsTest(CliTestCase):


### PR DESCRIPTION
Adding `isort` to keep the imports organized.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] ~Documentation has been updated to reflect changes, if applicable.~
- [ ] ~Changes are added to the [CHANGELOG](../CHANGELOG.md).~
