### PR TITLE
Use `item.json` in the create item test

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -39,7 +39,7 @@ class CommandsTest(CliTestCase):
             # Run your custom create-item command and validate
 
             # Example:
-            destination = os.path.join(tmp_dir, "collection.json")
+            destination = os.path.join(tmp_dir, "item.json")
             result = self.run_command([
                 "ephemeralcmd",
                 "create-item",


### PR DESCRIPTION
**Related Issue(s):** n/a

**Description:** The STAC file name should be `item.json` in the create-item test.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- ~[] Documentation has been updated to reflect changes, if applicable.~
- ~[ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).~
