### PR TITLE
Update license year to 2022

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 This software is licensed under the Apache 2 license, quoted below.
 
-Copyright 2021 COMPANY [COMPANY WEBPAGE URL]
+Copyright 2022 COMPANY [COMPANY WEBPAGE URL]
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of

--- a/src/stactools/ephemeral/commands.py
+++ b/src/stactools/ephemeral/commands.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 def create_ephemeralcmd_command(cli):
     """Creates the stactools-ephemeral command line utility."""
+
     @cli.group(
         "ephemeralcmd",
         short_help=("Commands for working with stactools-ephemeral"),

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8,6 +8,7 @@ from stactools.ephemeral.commands import create_ephemeralcmd_command
 
 
 class CommandsTest(CliTestCase):
+
     def create_subcommand_functions(self):
         return [create_ephemeralcmd_command]
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -4,5 +4,6 @@ import stactools.ephemeral
 
 
 class TestModule(unittest.TestCase):
+
     def test_version(self):
         self.assertIsNotNone(stactools.ephemeral.__version__)

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -4,6 +4,7 @@ from stactools.ephemeral import stac
 
 
 class StacTest(unittest.TestCase):
+
     def test_create_collection(self):
         # Write tests for each for the creation of a STAC Collection
         # Create the STAC Collection...


### PR DESCRIPTION
**Related Issue(s):** n/a

**Description:** Updates the template's license year to 2022.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).

