### PR TITLE
tests: update to use pytest

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,12 @@
 codespell
-coverage
 editorconfig-checker
 flake8
 isort
 jupyter
 mypy
 pylint
+pytest
+pytest-cov
 sphinx
 sphinx-autobuild
 sphinx-click

--- a/scripts/test
+++ b/scripts/test
@@ -26,7 +26,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             docs/*.rst docs/**/*.rst \
             docs/*.ipynb docs/**/*.ipynb
 
-        coverage run --source=${COVERAGE_DIRS} -m unittest discover tests/
+        pytest --cov=stactools ${COVERAGE_DIRS}
         coverage xml
     fi
 fi


### PR DESCRIPTION
**Related Issue(s):** stac-utils/stactools#220

**Description:** Update our development environment and scripts to use `pytest`. Doesn't require any test changes (thanks pytest!).

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.

