### PR TITLE
use pytest format in tests

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -22,14 +22,14 @@ class CommandsTest(CliTestCase):
 
             result = self.run_command(f"ephemeralcmd create-collection {destination}")
 
-            self.assertEqual(result.exit_code, 0, msg="\n{}".format(result.output))
+            assert result.exit_code == 0, "\n{}".format(result.output)
 
             jsons = [p for p in os.listdir(tmp_dir) if p.endswith(".json")]
-            self.assertEqual(len(jsons), 1)
+            assert len(jsons) == 1
 
             collection = pystac.read_file(destination)
-            self.assertEqual(collection.id, "my-collection-id")
-            # self.assertEqual(item.other_attr...
+            assert collection.id == "my-collection-id"
+            # assert collection.other_attr...
 
             collection.validate()
 
@@ -43,13 +43,13 @@ class CommandsTest(CliTestCase):
             result = self.run_command(
                 f"ephemeralcmd create-item {infile} {destination}"
             )
-            self.assertEqual(result.exit_code, 0, msg="\n{}".format(result.output))
+            assert result.exit_code == 0, "\n{}".format(result.output)
 
             jsons = [p for p in os.listdir(tmp_dir) if p.endswith(".json")]
-            self.assertEqual(len(jsons), 1)
+            assert len(jsons) == 1
 
             item = pystac.read_file(destination)
-            self.assertEqual(item.id, "my-item-id")
-            # self.assertEqual(item.other_attr...
+            assert item.id == "my-item-id"
+            # assert item.other_attr...
 
             item.validate()

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,8 +1,5 @@
-import unittest
-
 import stactools.ephemeral
 
 
-class TestModule(unittest.TestCase):
-    def test_version(self) -> None:
-        self.assertIsNotNone(stactools.ephemeral.__version__)
+def test_version() -> None:
+    assert stactools.ephemeral.__version__ is not None

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1,30 +1,28 @@
-import unittest
-
 from stactools.ephemeral import stac
 
 
-class StacTest(unittest.TestCase):
-    def test_create_collection(self) -> None:
-        # Write tests for each for the creation of a STAC Collection
-        # Create the STAC Collection...
-        collection = stac.create_collection()
-        collection.set_self_href("")
+def test_create_collection() -> None:
+    # Write tests for each for the creation of a STAC Collection
+    # Create the STAC Collection...
+    collection = stac.create_collection()
+    collection.set_self_href("")
 
-        # Check that it has some required attributes
-        self.assertEqual(collection.id, "my-collection-id")
-        # self.assertEqual(collection.other_attr...
+    # Check that it has some required attributes
+    assert collection.id == "my-collection-id"
+    # self.assertEqual(collection.other_attr...
 
-        # Validate
-        collection.validate()
+    # Validate
+    collection.validate()
 
-    def test_create_item(self) -> None:
-        # Write tests for each for the creation of STAC Items
-        # Create the STAC Item...
-        item = stac.create_item("/path/to/asset.tif")
 
-        # Check that it has some required attributes
-        self.assertEqual(item.id, "my-item-id")
-        # self.assertEqual(item.other_attr...
+def test_create_item() -> None:
+    # Write tests for each for the creation of STAC Items
+    # Create the STAC Item...
+    item = stac.create_item("/path/to/asset.tif")
 
-        # Validate
-        item.validate()
+    # Check that it has some required attributes
+    assert item.id == "my-item-id"
+    # self.assertEqual(item.other_attr...
+
+    # Validate
+    item.validate()


### PR DESCRIPTION
**Related Issue(s):**
#62 

**Description:**
Updated examples tests to use pytest format.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable. - N/A
- [ ] Examples have been updated to reflect changes, if applicable - N/A
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md). - N/A
