### PR TITLE
Update Python versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash -l {0}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get -y -q update \
 RUN python -m venv /opt/venv
 RUN pip install . --no-binary rasterio \
     && ls /opt/venv \
-    && rm -r /opt/venv/lib/python3.10/site-packages/stactools/ephemeral
+    && rm -r /opt/venv/lib/python3.11/site-packages/stactools/ephemeral
 
 
 FROM dependencies as builder


### PR DESCRIPTION
**Related Issue(s):**
- Closes #79 

**Description:**
We could have gotten fancier w/ the Python version, but the miniconda version updates infrequently enough that it's not worth it IMO. Includes a sidecar add of Python 3.11 to the CI workflow.
