### PR TITLE
Specify language_version for markdownlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,4 @@ repos:
     rev: v0.33.0
     hooks:
       - id: markdownlint
+        language_version: "18.17.1"


### PR DESCRIPTION
**Related Issue(s):**
- Closes #68 

**Description:**
From the [pre-commit docs](https://pre-commit.com/#pre-commit-configyaml---hooks):

> If the machine does not have node installed, pre-commit will download and build a copy of node.

So I think this should fix any problems about an incorrect node version.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [ ] Examples have been updated to reflect changes, if applicable
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
