### PR TITLE
Fix typo in project.urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ dev = [
 docs = ["pystac~=1.8", "ipykernel~=6.25", "jinja2~=3.1"]
 
 [project.urls]
-Github = "https://github.com/stactools-packges/ephemeral"
-Issues = "https://github.com/stactools-packges/ephemeral/issues"
+Github = "https://github.com/stactools-packages/ephemeral"
+Issues = "https://github.com/stactools-packages/ephemeral/issues"
 
 [build-system]
 requires = ["setuptools", "wheel"]


### PR DESCRIPTION
The links to the GitHub pages were broken by default.
